### PR TITLE
Simplify async stream

### DIFF
--- a/DataStoreDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DataStoreDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "d4a2913820421d4033a2f21cd0f783dc258fac29",
-        "version" : "2.5.0"
+        "revision" : "7e8bc10cebe655c5b778e0a0e29e278b3e99e08b",
+        "version" : "2.6.0"
       }
     },
     {

--- a/DataStoreDemo/model/MainViewModel.swift
+++ b/DataStoreDemo/model/MainViewModel.swift
@@ -36,28 +36,19 @@ extension MainView {
             // when we did not load podcast for this category yet
             print("Loading podcast for \(category)")
             self.podcastState[category] = .loading
-            
-            //            // the callback version
-            //            self.backend.loadPodcast(for: category) { result in
-            //                switch(result) {
-            //                case .success(let podcastData):
-            //                    print("Podcast callback yielded \(podcastData.count) results")
-            //                    let result = self.convertDataToModel(podcastData: podcastData)
-            //                    self.podcastState[category] = .dataAvailable(result)
-            //                case .failure(let error):
-            //                    self.podcastState[category] = .error(error)
-            //                }
-            //            }
 
-            // the asyncstream version
+            // using an asyncstream
             do {
-                for try await data in self.backend.loadPodcast(for: category) {
+                print("==== ENTERING PODCAST LOOP =====")
+                for try await snapshot in self.backend.loadPodcast(for: category) {
+                    let data = snapshot.items
                     print("==== PODCAST LOOP yielded \(data.count) results")
                     let result = convertDataToModel(podcastData :data)
                     self.podcastState[category] = .dataAvailable(result)
                 }
                 print("==== EXITED PODCAST LOOP =====")
             } catch {
+                print("==== ERROR DURING PODCAST LOOP =====")
                 self.podcastState[category] = .error(error)
             }
         }
@@ -77,22 +68,10 @@ extension MainView {
             
             episodeState[podcast.id] = . loading
             
-            //         // the callback version
-            //        self.backend.loadEpisodes(for: podcast) { result in
-            //            switch(result) {
-            //            case .success(let data):
-            //                print("Episode callback yielded \(data.count) values")
-            //                let result = self.convertDataToModel(episodeData: data)
-            //                self.episodeState[podcast.id] = .dataAvailable(result)
-            //            case .failure(let error):
-            //                self.episodeState[podcast.id] = .error(error)
-            //
-            //            }
-            //        }
-            
-            // the AsyncStream version
+            // using an AsyncStream
             do {
-                for try await data in self.backend.loadEpisodes(for: podcast) {
+                for try await snapshot in self.backend.loadEpisodes(for: podcast) {
+                    let data = snapshot.items
                     print("==== EPISODE LOOP yielded \(data.count) results")
                     let result = convertDataToModel(episodeData: data)
                     self.episodeState[podcast.id] = .dataAvailable(result)

--- a/DataStoreDemo/model/MainViewModel.swift
+++ b/DataStoreDemo/model/MainViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Stormacq, Sebastien on 06/11/2022.
 //
 
-//import Combine
 import SwiftUI
 
 // to generate random text when creating episodes
@@ -32,7 +31,7 @@ extension MainView {
         }
         
         func loadPodcasts(for category: Podcast.Category) async {
-            
+                        
             // when we did not load podcast for this category yet
             print("Loading podcast for \(category)")
             self.podcastState[category] = .loading

--- a/DataStoreDemo/service/Backend.swift
+++ b/DataStoreDemo/service/Backend.swift
@@ -30,8 +30,8 @@ class Backend {
     
     // we need to keep a reference to the subscription streams, otherwise the language runtime
     // release the objects.
-    var podcastSubscriptions: [Podcast.Category:AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<PodcastData>>] = [:]
-    var episodeSubscriptions: [Podcast:AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<EpisodeData>>] = [:]
+    private var podcastSubscriptions: [Podcast.Category:AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<PodcastData>>] = [:]
+    private var episodeSubscriptions: [Podcast:AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<EpisodeData>>] = [:]
 
     //MARK: initialization
             
@@ -43,7 +43,7 @@ class Backend {
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.add(plugin: AWSAPIPlugin())
             try Amplify.configure()
-            Amplify.Logging.logLevel = .verbose
+//            Amplify.Logging.logLevel = .verbose
             print("Amplify configured with DataStore plugin")
             
         } catch {
@@ -96,7 +96,7 @@ class Backend {
                     Amplify.DataStore
                            .observeQuery(for: PodcastData.self,
                                          where: p.category == PodcastCategoryData(from: category))
-        }
+        } 
 
         return podcastSubscriptions[category]!
     }

--- a/DataStoreDemo/service/Backend.swift
+++ b/DataStoreDemo/service/Backend.swift
@@ -29,11 +29,7 @@ import AWSAPIPlugin
 class Backend {
     
     //MARK: initialization
-        
-    // declare a cancellable to hold onto the amplify subscription
-    private(set) var episodeSubscription: [String:AnyCancellable] = [:]
-    private(set) var podcastSubscription: [Podcast.Category:AnyCancellable] = [:]
-    
+            
     init() {
         do {
             
@@ -84,135 +80,29 @@ class Backend {
         return Podcast.Category.allCases
     }
     
-    // async / await version instead of using callbacks, to be called from ViewModel
-    // https://www.avanderlee.com/swift/asyncthrowingstream-asyncstream/
-    func loadPodcast(for category: Podcast.Category) -> AsyncThrowingStream<[PodcastData], Error> {
+    // load podcast from local store and subscribe to changes
+    // this allows to start with an empty store and received sync data as the local store is updated
+    func loadPodcast(for category: Podcast.Category) -> AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<PodcastData>> {
         
         print("[BACKEND] Loading podcast with AsyncThrowingStream")
         
-        return AsyncThrowingStream { continuation in
-            continuation.onTermination = { @Sendable status in
-                       print("[BACKEND] streaming podcast terminated with status : \(status)")
-            }
-            loadPodcast(for: category) { result in
-                switch(result) {
-                case .success(let data):
-                    print("[BACKEND] streaming podcast success")
-                    continuation.yield(data)
-                case .failure(let error):
-                    print("[BACKEND] streaming podcast failure")
-                    continuation.finish(throwing: error)
-                }
-            }
-        }
-    }
-    
-    // load podcast from local store and subscribe to changes
-    // this allows to start with an empty store and received sync data as the local store is updated
-    private func loadPodcast(for category: Podcast.Category, callback: @escaping (Result<[PodcastData],Error>) -> Void) {
-
-        print("[BACKEND] LOAD PODCAST")
-        
-        // cancel previous subscription if any
-        if let s = self.podcastSubscription[category] {
-            print("[BACKEND] Canceling previous subscription for category \(category)")
-            s.cancel()
-        }
-
-        // load podcasts and subscribe to changes
-        // https://docs.amplify.aws/lib/datastore/real-time/q/platform/ios/#observe-query-results-in-real-time
         let p = PodcastData.keys
-        self.podcastSubscription[category] = Amplify.Publisher.create(
-            Amplify.DataStore.observeQuery(for: PodcastData.self,
-                                           where: p.category == PodcastCategoryData(from: category))
-        )
+        return Amplify.DataStore
+                      .observeQuery(for: PodcastData.self,
+                                    where: p.category == PodcastCategoryData(from: category))
 
-        .sink(
-                receiveCompletion: { completion in
-                    if case let .failure(error) = completion {
-                        print("[Podcast snapshot] Subscription received error - \(error)")
-
-                        callback(Result.failure(error))
-                    }
-                    print("[Podcast snapshot] received completion")
-                },
-                receiveValue: { querySnapshot in
-                    print("[Podcast snapshot] item count: \(querySnapshot.items.count), isSynced: \(querySnapshot.isSynced)")
-
-                    callback(Result.success(querySnapshot.items))
-                })
-    }
-
-//    func loadPodcast(for category: Podcast.Category) async throws -> [PodcastData] {
-//
-//            // load podcasts
-//            let p = PodcastData.keys
-//            return try await Amplify.DataStore.query(PodcastData.self,
-//                                              where: p.category == PodcastCategoryData(from: category))
-//    }
-//
-//    func loadEpisodes(for podcast: Podcast) async throws -> [EpisodeData] {
-//
-//            // load podcasts
-//            let e = EpisodeData.keys
-//            return try await Amplify.DataStore.query(EpisodeData.self,
-//                                                     where: e.podcastDataEpisodesId == podcast.id)
-//    }
-    
-    
-    // async / await version instead of using callbacks, to be called from ViewModel
-    // https://www.avanderlee.com/swift/asyncthrowingstream-asyncstream/
-    func loadEpisodes(for podcast: Podcast) -> AsyncThrowingStream<[EpisodeData], Error> {
-        return AsyncThrowingStream { continuation in
-            continuation.onTermination = { @Sendable status in
-                print("[BACKEND] streaming episode terminated with status : \(status)")
-            }
-            loadEpisodes(for: podcast) { result in
-                switch(result) {
-                case .success(let data):
-                    print("[BACKEND] streaming episode success")
-                    continuation.yield(data)
-                case .failure(let error):
-                    print("[BACKEND] streaming episode failure")
-                    continuation.finish(throwing: error)
-                }
-            }
-        }
     }
     
-    // load episodes from local store and subscribe for updates when backend is updated
-    private func loadEpisodes(for podcast: Podcast, callback: @escaping (Result<[EpisodeData],Error>) -> Void) {
-
+    func loadEpisodes(for podcast: Podcast) -> AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<EpisodeData>> {
         print("[BACKEND] LOAD EPISODES for podcast \(podcast.id)")
-
-        // cancel previous subscription if any
-        if let s = self.episodeSubscription[podcast.id] {
-            print("[BACKEND] Canceling previous EPISODE subscription for podcast \(podcast)")
-            s.cancel()
-        }
-
+        
         // load episodes
         let e = EpisodeData.keys
 
-        self.episodeSubscription[podcast.id] = Amplify.Publisher.create(
-            Amplify.DataStore.observeQuery(for: EpisodeData.self,
-                                           where: e.podcastDataEpisodesId == podcast.id)
-        )
+        return Amplify.DataStore
+                      .observeQuery(for: EpisodeData.self,
+                                    where: e.podcastDataEpisodesId == podcast.id)
 
-        .sink(
-            receiveCompletion: { completion in
-                if case let .failure(error) = completion {
-                    print("[Episode snapshot] Subscription received error - \(error)")
-                    
-                    callback(Result.failure(error))
-                }
-                print("[Episode snapshot] received completion")
-            },
-            receiveValue: { querySnapshot in
-                print("[Episode snapshot] item count: \(querySnapshot.items.count), isSynced: \(querySnapshot.isSynced)")
-
-                callback(Result.success(querySnapshot.items))
-            })
     }
     
     func addEpisode(_ episode: EpisodeData) async throws  {


### PR DESCRIPTION
The `Amplify.observeQuery()` natively returns an implementation of `AsyncSequence`.

Following the doc, I naively build an `AsyncStreaming` construct on top of the Combine publisher, as documented.
https://docs.amplify.aws/lib/datastore/real-time/q/platform/ios/#observe-query-results-in-real-time 

But this is not necessary.  The code can directly consume the stream returned by `observeQuery()` in a `for await` loop.